### PR TITLE
Normalize legacy purchase timestamps in frontend and add ACC-SUP-02 acceptance test

### DIFF
--- a/docs/ACCEPTANCE_CHECKLIST.md
+++ b/docs/ACCEPTANCE_CHECKLIST.md
@@ -42,6 +42,7 @@ Mục tiêu:
 | 20  | ACC-SYNC-01  | P0       | Nhiều máy / create-order       | Màn bán hàng tự refresh tồn kho và giá sau thay đổi từ máy khác           | Auto | `tests/integration/cross-client-sync.spec.js`                                                    |
 | 21  | ACC-SYNC-02  | P0       | Nhiều máy / draft cart         | Lưu dữ liệu stale bị chặn với conflict metadata                           | Auto | `tests/integration/workflow-phase-c.spec.js`                                                     |
 | 22  | ACC-SYNC-03  | P0       | Nhiều máy / draft purchase     | Lưu dữ liệu stale bị chặn với conflict metadata                           | Auto | `tests/integration/workflow-phase-c.spec.js`                                                     |
+| 23  | ACC-SUP-02   | P0       | Nhà cung cấp + dữ liệu legacy  | Tạo mới NCC không bị lỗi sync khi có phiếu `paid` legacy dùng `received_at` | Auto | `tests/integration/acceptance-checklist.spec.js`                                                 |
 
 ## 3. Bộ chạy tự động chuẩn cho Codex agent
 

--- a/static/app.js
+++ b/static/app.js
@@ -996,9 +996,9 @@ function syncSalesState() {
       status: purchase.status || "draft",
       createdAt: purchase.createdAt || nowIso(),
       updatedAt: purchase.updatedAt || purchase.createdAt || nowIso(),
-      receivedAt: purchase.receivedAt || null,
-      paidAt: purchase.paidAt || null,
-      receiptCode: purchase.receiptCode || "",
+      receivedAt: purchase.receivedAt || purchase.received_at || null,
+      paidAt: purchase.paidAt || purchase.paid_at || null,
+      receiptCode: purchase.receiptCode || purchase.receipt_code || "",
       items: Array.isArray(purchase.items)
         ? purchase.items
             .map((item) => {

--- a/tests/integration/acceptance-checklist.spec.js
+++ b/tests/integration/acceptance-checklist.spec.js
@@ -74,3 +74,69 @@ test("ACC-REP-01 and ACC-HIS-01 reports refresh and history screen render health
 
   expectNoRuntimeErrors(runtime);
 });
+
+test("ACC-SUP-02 suppliers create stays healthy with legacy paid purchases using received_at", async ({ page, request }) => {
+  const runtime = attachRuntimeTracking(page);
+  const now = new Date().toISOString();
+  const supplierName = `NCC Legacy ${Date.now()}`;
+
+  const stateResponse = await request.get("/api/state?transaction_limit=16");
+  expect(stateResponse.ok()).toBeTruthy();
+  const originalState = await stateResponse.json();
+
+  const legacyPaidPurchase = {
+    id: `purchase_legacy_paid_${Date.now()}`,
+    supplierName: "NCC Legacy Locked",
+    note: "Legacy payload uses received_at",
+    status: "paid",
+    createdAt: now,
+    updatedAt: now,
+    paidAt: now,
+    received_at: now,
+    receiptCode: `PN-LEGACY-${Date.now()}`,
+    items: [],
+  };
+
+  try {
+    const seedResponse = await request.put("/api/state", {
+      data: {
+        purchases: [...(originalState.purchases || []), legacyPaidPurchase],
+      },
+    });
+    expect(seedResponse.ok()).toBeTruthy();
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await switchMenu(page, "suppliers");
+    await expectScreenTitle(page, "Nhà cung cấp");
+    await page.locator("#supplierFormToggleButton").click();
+    await expect(page.locator("#supplierFormSection")).not.toHaveClass(/is-collapsed/);
+
+    await page.locator("#supplierNameInput").fill(supplierName);
+    await page.locator("#supplierPhoneInput").fill("0909000098");
+    await page.locator("#supplierAddressInput").fill("Dia chi NCC legacy");
+    await page.locator("#supplierForm button[type=\"submit\"]").click();
+
+    const toastText = await collectToast(page, runtime, "acc-supplier-legacy-purchase-create", {
+      errorPattern: /^$/,
+    });
+    expect(toastText).toContain("Đã lưu nhà cung cấp");
+
+    const latestStateResponse = await request.get("/api/state?transaction_limit=16");
+    expect(latestStateResponse.ok()).toBeTruthy();
+    const latestState = await latestStateResponse.json();
+    expect((latestState.suppliers || []).some((supplier) => supplier.name === supplierName)).toBeTruthy();
+  } finally {
+    await request.put("/api/state", {
+      data: {
+        customers: originalState.customers,
+        suppliers: originalState.suppliers,
+        carts: originalState.carts,
+        purchases: originalState.purchases,
+      },
+    });
+  }
+
+  expectNoRuntimeErrors(runtime);
+});


### PR DESCRIPTION
### Motivation
- Fix a reproducible error when creating a supplier on environments with legacy purchase payloads that use snake_case timestamps (e.g. `received_at`), which caused backend validation to reject saves with: "Phiếu nhập đã thanh toán phải có thời điểm nhập kho trước đó.".
- Keep backward compatibility with older synced state formats so legacy records do not break current workflows.
- Add automated coverage for the supplier / legacy-payload regression to prevent future regressions.

### Description
- Update frontend state normalization in `static/app.js` to fallback to legacy fields when mapping purchases: use `purchase.received_at`, `purchase.paid_at`, and `purchase.receipt_code` when `receivedAt`/`paidAt`/`receiptCode` are missing.
- Add a Playwright acceptance test `ACC-SUP-02` in `tests/integration/acceptance-checklist.spec.js` that seeds a legacy `paid` purchase using `received_at` and verifies creating a supplier does not trigger the sync validation error.
- Register the new case `ACC-SUP-02` in `docs/ACCEPTANCE_CHECKLIST.md` so it is included in the acceptance checklist.

### Testing
- Syntax checks passed: `node --check static/app.js` and `python -m py_compile app.py` executed successfully.
- Unit tests passed: `python -m unittest discover -s tests` (12 tests, all OK).
- Acceptance tests passed: `npm run test:acceptance -- --grep "ACC-SUP-02|ACC-SUP-01"` (the new `ACC-SUP-02` passed) and full `npm run test:acceptance` (18 acceptance tests passed).
- The added test verifies the original error is not reproducible after the change (test run green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d60f7a90388327a374732ffd070bac)