### PR TITLE
Fix reset_all_data foreign key failure during init --reset

### DIFF
--- a/qltpchay/store.py
+++ b/qltpchay/store.py
@@ -1295,10 +1295,44 @@ class InventoryStore:
 
     def reset_all_data(self) -> None:
         with self._connect() as connection:
-            connection.execute("DELETE FROM transactions")
-            connection.execute("DELETE FROM audit_logs")
-            connection.execute("DELETE FROM products")
-            connection.execute("DELETE FROM sqlite_sequence WHERE name IN ('products', 'transactions', 'audit_logs')")
+            existing_tables = {
+                row["name"]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).fetchall()
+            }
+
+            # Xóa theo thứ tự từ bảng con -> bảng cha để tránh lỗi FOREIGN KEY.
+            reset_order = [
+                "inventory_receipt_items",
+                "inventory_receipts",
+                "cart_items",
+                "purchase_items",
+                "transactions",
+                "carts",
+                "purchases",
+                "audit_logs",
+                "customers",
+                "suppliers",
+                "products",
+                "app_state",
+            ]
+            for table_name in reset_order:
+                if table_name in existing_tables:
+                    connection.execute(f"DELETE FROM {table_name}")
+
+            if "sqlite_sequence" in existing_tables:
+                sequence_tables = tuple(
+                    table_name
+                    for table_name in ("products", "transactions", "audit_logs", "inventory_receipts", "inventory_receipt_items")
+                    if table_name in existing_tables
+                )
+                if sequence_tables:
+                    placeholders = ",".join("?" for _ in sequence_tables)
+                    connection.execute(
+                        f"DELETE FROM sqlite_sequence WHERE name IN ({placeholders})",
+                        sequence_tables,
+                    )
 
     def get_product_by_id(self, product_id: int) -> dict:
         with self._connect() as connection:


### PR DESCRIPTION
### Motivation
- `python app.py init --reset` could raise `sqlite3.IntegrityError: FOREIGN KEY constraint failed` when deleting tables because child rows referenced parent tables (notably `inventory_receipt_items.transaction_id -> transactions.id`).
- The reset routine previously deleted a small set of tables in an order that did not account for newer workflow tables, making it fragile across schema versions.
- The goal is to make `reset_all_data()` robust and backward-compatible so reset works on DBs with different sets of tables.

### Description
- Updated `InventoryStore.reset_all_data()` to enumerate existing tables and delete them in child-to-parent order to satisfy foreign key constraints. 
- The reset now includes newer workflow tables (`inventory_receipt_items`, `inventory_receipts`, `cart_items`, `purchase_items`, `carts`, `purchases`, `customers`, `suppliers`, `app_state`) while only touching tables that actually exist. 
- Clearing of `sqlite_sequence` is restricted to autoincrement tables that exist in the current database to avoid incorrect sequence operations on older schemas.

### Testing
- Ran `node --check static/app.js` with no errors. 
- Ran `python -m py_compile app.py` with no errors. 
- Ran unit tests with `python -m unittest discover -s tests` and all tests passed (`Ran 20 tests — OK`). 
- Executed `python3 app.py init --reset`; the reset now proceeds past the FK deletion stage but the run failed later due to a missing seed file `data/List_price.txt` in the environment rather than a foreign key error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc598d4874832fa2ba0d6c3f73073e)