### PR TITLE
Fix dữ liệu Nháp nhưng bên trong còn sót marker kiểu paidAt/receivedA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Quy ước này giúp khi tách Issue song song, team UI chỉ bám `ui/*`, team
 - Quản lý nhập hàng với phiếu nhập nháp, trạng thái đặt hàng/nhập kho và gợi ý sản phẩm cần nhập
 - Có nút `NCC` ở màn nhập hàng để mở nhanh form tạo/sửa nhà cung cấp với tên đang gõ; nếu NCC đã tồn tại app sẽ mở thẳng chế độ sửa rồi quay lại áp ngay vào phiếu nhập
 - Phiếu nhập chỉ được chuyển sang `Đã thanh toán` sau khi đã `Nhập kho`, để tránh trả tiền khi hàng chưa được nhận vào tồn
-- Nếu dữ liệu cũ sinh ra phiếu ở trạng thái `Đã thanh toán` nhưng chưa có mốc `Nhập kho` hợp lệ, app sẽ hiện cảnh báo và cho phép `Hủy phiếu` hoặc `Xóa phiếu` để dọn dữ liệu lỗi mà không khôi phục lại thành nháp
+- Nếu dữ liệu cũ làm phiếu bị lệch trạng thái, ví dụ đang dính marker `Đã thanh toán` nhưng chưa có `Nhập kho` thật hoặc ngoài màn hình lại đang hiện như `Nháp`, app sẽ hiện cảnh báo và cho phép `Hủy phiếu` hoặc `Xóa phiếu` để dọn dữ liệu lỗi mà không khôi phục lại thành nháp
 - Có API chứng từ điều chỉnh cho Phase B gồm: `phiếu điều chỉnh tồn`, `phiếu trả hàng khách`, `phiếu trả NCC` để không sửa ngược chứng từ cũ
 - Có audit log Phase D cho thay đổi trạng thái đơn/phiếu, thay đổi giá chung và lưu người thao tác để truy vết
 - Báo cáo nhập xuất theo tháng, tách riêng `hoàn khách`, `trả NCC`, `điều chỉnh tồn`, có thêm khối audit chứng từ để tra cứu ngay trong màn `Báo cáo`

--- a/docs/HUONG_DAN_SU_DUNG.md
+++ b/docs/HUONG_DAN_SU_DUNG.md
@@ -236,7 +236,7 @@ Màn này có 2 phần:
 11. Khi đã gửi đặt hàng, bấm `Đã đặt hàng`
 12. Khi hàng về thực tế, bấm `Nhập kho`
 13. Chỉ sau khi phiếu đã ở trạng thái `Đã nhập kho`, mới bấm `Đã thanh toán`
-14. Nếu gặp phiếu cũ đang là `Đã thanh toán` nhưng không có mốc `Nhập kho` hợp lệ, đó là dữ liệu lỗi; có thể bấm `Hủy phiếu` hoặc `Xóa phiếu` để dọn lỗi ngay, app sẽ không khôi phục lại thành `Nháp`
+14. Nếu gặp phiếu cũ bị lệch trạng thái, ví dụ thực tế đã dính `Đã thanh toán` nhưng không có mốc `Nhập kho` hợp lệ hoặc ngoài màn hình lại đang hiện như `Nháp`, đó là dữ liệu lỗi; có thể bấm `Hủy phiếu` hoặc `Xóa phiếu` để dọn lỗi ngay, app sẽ không khôi phục lại thành `Nháp`
 
 ### Ý nghĩa trạng thái phiếu nhập
 
@@ -250,7 +250,7 @@ Lưu ý:
 
 - chỉ `Nháp` và `Đã đặt` mới được sửa trực tiếp dòng hàng
 - phiếu đã `Đã nhập kho`, `Đã thanh toán` hoặc `Đã hủy` sẽ chuyển sang chế độ chỉ xem để giữ lịch sử đúng workflow
-- kể cả `Master Admin` cũng không được xóa hoặc hủy ngược các phiếu đã khóa, trừ ngoại lệ phiếu lỗi dữ liệu `Đã thanh toán` nhưng chưa nhập kho nói ở trên
+- kể cả `Master Admin` cũng không được xóa hoặc hủy ngược các phiếu đã khóa, trừ ngoại lệ phiếu lỗi dữ liệu bị lệch marker/trạng thái nói ở trên
 
 ## 9. Luồng quản lý nhà cung cấp
 

--- a/docs/TEST_CASE_DESCRIPTIONS.md
+++ b/docs/TEST_CASE_DESCRIPTIONS.md
@@ -69,14 +69,15 @@ Lưu ý:
 | 50 | `UT-DB-06` | Kiểm tra backend không cho tạo phiếu điều chỉnh tồn nếu thiếu lý do. |
 | 51 | `UT-DB-07` | Kiểm tra backend cho phép xóa phiếu nhập lỗi `paid` nhưng chưa có receipt nhập kho thật, đồng thời gỡ các liên kết source tham chiếu tới mã phiếu lỗi đó. |
 | 52 | `UT-DB-08` | Kiểm tra backend vẫn chặn repair/xóa đối với phiếu `paid` hợp lệ đã có receipt nhập kho thật. |
-| 53 | `UT-NORM-01` | Kiểm tra `save_sync_state` persist đúng dữ liệu sang các bảng quan hệ chuẩn hóa. |
-| 54 | `UT-NORM-02` | Kiểm tra các loại receipt được persist đúng vào cấu trúc bảng chuẩn hóa mới. |
-| 55 | `UT-NORM-03` | Kiểm tra app state legacy được migrate sang cấu trúc bảng quan hệ khi khởi động. |
-| 56 | `UT-SYNC-01` | Kiểm tra sync state chấp nhận cập nhật khi `expected_updated_at` khớp. |
-| 57 | `UT-SYNC-02` | Kiểm tra sync state từ chối cập nhật khi `expected_updated_at` bị stale. |
-| 58 | `UT-AUD-01` | Kiểm tra thay đổi trạng thái đơn hàng được ghi audit kèm actor. |
-| 59 | `UT-AUD-02` | Kiểm tra thay đổi trạng thái phiếu nhập được ghi audit kèm actor. |
-| 60 | `UT-AUD-03` | Kiểm tra receipt history trả đúng source link và audit message cho các phiếu Phase B. |
-| 61 | `UT-HIS-01` | Kiểm tra product history hỗ trợ lọc theo actor ở backend. |
-| 62 | `UT-HIS-02` | Kiểm tra product history hỗ trợ lọc theo khoảng ngày ở backend. |
-| 63 | `UT-REP-01` | Kiểm tra monthly report backend tách riêng sale/purchase với trả khách, trả NCC và điều chỉnh tồn. |
+| 53 | `UT-DB-09` | Kiểm tra backend cho phép hủy phiếu đang hiện là `draft` nhưng còn sót marker `paid/receiptCode` do lệch dữ liệu, và dọn sạch các marker này. |
+| 54 | `UT-NORM-01` | Kiểm tra `save_sync_state` persist đúng dữ liệu sang các bảng quan hệ chuẩn hóa. |
+| 55 | `UT-NORM-02` | Kiểm tra các loại receipt được persist đúng vào cấu trúc bảng chuẩn hóa mới. |
+| 56 | `UT-NORM-03` | Kiểm tra app state legacy được migrate sang cấu trúc bảng quan hệ khi khởi động. |
+| 57 | `UT-SYNC-01` | Kiểm tra sync state chấp nhận cập nhật khi `expected_updated_at` khớp. |
+| 58 | `UT-SYNC-02` | Kiểm tra sync state từ chối cập nhật khi `expected_updated_at` bị stale. |
+| 59 | `UT-AUD-01` | Kiểm tra thay đổi trạng thái đơn hàng được ghi audit kèm actor. |
+| 60 | `UT-AUD-02` | Kiểm tra thay đổi trạng thái phiếu nhập được ghi audit kèm actor. |
+| 61 | `UT-AUD-03` | Kiểm tra receipt history trả đúng source link và audit message cho các phiếu Phase B. |
+| 62 | `UT-HIS-01` | Kiểm tra product history hỗ trợ lọc theo actor ở backend. |
+| 63 | `UT-HIS-02` | Kiểm tra product history hỗ trợ lọc theo khoảng ngày ở backend. |
+| 64 | `UT-REP-01` | Kiểm tra monthly report backend tách riêng sale/purchase với trả khách, trả NCC và điều chỉnh tồn. |

--- a/docs/TEST_CASE_INDEX.md
+++ b/docs/TEST_CASE_INDEX.md
@@ -75,17 +75,18 @@ Mục tiêu:
 | 50 | `UT-DB-06` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_db_06_inventory_adjustment_requires_reason` |
 | 51 | `UT-DB-07` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_db_07_repair_purchase_document_deletes_invalid_paid_purchase_and_detaches_links` |
 | 52 | `UT-DB-08` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_db_08_repair_purchase_document_rejects_valid_paid_purchase_with_receipt` |
-| 53 | `UT-NORM-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_norm_01_save_sync_state_persists_relational_tables` |
-| 54 | `UT-NORM-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_norm_02_receipt_creation_persists_normalized_receipt_tables` |
-| 55 | `UT-NORM-03` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_norm_03_legacy_app_state_is_migrated_to_normalized_tables_on_bootstrap` |
-| 56 | `UT-SYNC-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_sync_01_save_sync_state_accepts_matching_expected_updated_at` |
-| 57 | `UT-SYNC-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_sync_02_save_sync_state_rejects_stale_expected_updated_at` |
-| 58 | `UT-AUD-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_aud_01_save_sync_state_logs_cart_status_changes_with_actor` |
-| 59 | `UT-AUD-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_aud_02_save_sync_state_logs_purchase_status_changes_with_actor` |
-| 60 | `UT-AUD-03` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_aud_03_receipt_history_lists_phase_b_receipts_with_source_context` |
-| 61 | `UT-HIS-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_his_01_product_history_supports_actor_filter` |
-| 62 | `UT-HIS-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_his_02_product_history_supports_date_range_filter` |
-| 63 | `UT-REP-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_rep_01_monthly_report_separates_phase_b_receipts_from_sales_and_purchases` |
+| 53 | `UT-DB-09` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_db_09_repair_purchase_document_cancels_draft_with_paid_markers` |
+| 54 | `UT-NORM-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_norm_01_save_sync_state_persists_relational_tables` |
+| 55 | `UT-NORM-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_norm_02_receipt_creation_persists_normalized_receipt_tables` |
+| 56 | `UT-NORM-03` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_norm_03_legacy_app_state_is_migrated_to_normalized_tables_on_bootstrap` |
+| 57 | `UT-SYNC-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_sync_01_save_sync_state_accepts_matching_expected_updated_at` |
+| 58 | `UT-SYNC-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_sync_02_save_sync_state_rejects_stale_expected_updated_at` |
+| 59 | `UT-AUD-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_aud_01_save_sync_state_logs_cart_status_changes_with_actor` |
+| 60 | `UT-AUD-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_aud_02_save_sync_state_logs_purchase_status_changes_with_actor` |
+| 61 | `UT-AUD-03` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_aud_03_receipt_history_lists_phase_b_receipts_with_source_context` |
+| 62 | `UT-HIS-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_his_01_product_history_supports_actor_filter` |
+| 63 | `UT-HIS-02` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_his_02_product_history_supports_date_range_filter` |
+| 64 | `UT-REP-01` | `tests/test_app.py` | `python -m unittest tests.test_app.InventoryStoreTests.test_ut_rep_01_monthly_report_separates_phase_b_receipts_from_sales_and_purchases` |
 
 ## 3. Lệnh chạy nhanh theo nhóm
 

--- a/qltpchay/store.py
+++ b/qltpchay/store.py
@@ -1840,15 +1840,23 @@ class InventoryStore:
         connection: sqlite3.Connection,
         purchase: dict,
     ) -> bool:
-        if str(purchase.get("status") or "draft") != "paid":
-            return False
+        status = str(purchase.get("status") or "draft")
         receipt_code = str(purchase.get("receiptCode") or purchase.get("receipt_code") or "").strip()
         receipt_row = self._get_inventory_receipt_by_code(
             connection,
             receipt_code,
             receipt_type="purchase",
         )
-        return receipt_row is None
+        if receipt_row is not None:
+            return False
+        has_received_at = bool(purchase.get("receivedAt") or purchase.get("received_at"))
+        has_paid_at = bool(purchase.get("paidAt") or purchase.get("paid_at"))
+        has_receipt_code = bool(receipt_code)
+        if status == "paid":
+            return True
+        if status in {"draft", "ordered"} and (has_received_at or has_paid_at or has_receipt_code):
+            return True
+        return False
 
     def _clear_inventory_receipt_source_links(
         self,
@@ -1908,9 +1916,15 @@ class InventoryStore:
 
             current_status = str(target.get("status") or "draft")
             is_invalid_paid = self._is_repairable_invalid_purchase(connection, target)
-            if current_status != "draft" and not is_invalid_paid:
+            is_regular_delete_allowed = current_status == "draft"
+            is_regular_cancel_allowed = current_status in {"draft", "ordered"}
+            if clean_action == "delete":
+                action_allowed = is_regular_delete_allowed or is_invalid_paid
+            else:
+                action_allowed = is_regular_cancel_allowed or is_invalid_paid
+            if not action_allowed:
                 raise ValueError(
-                    "Chỉ được xóa/hủy phiếu nhập nháp hoặc phiếu lỗi đã thanh toán nhưng chưa nhập kho."
+                    "Chỉ được xóa/hủy phiếu nhập nháp, hủy phiếu đã đặt, hoặc xử lý phiếu lỗi chưa có nhập kho thật."
                 )
 
             source_receipt_code = str(
@@ -1956,9 +1970,9 @@ class InventoryStore:
             )
 
             repaired_label = (
-                "phiếu lỗi đã thanh toán nhưng chưa nhập kho"
+                "phiếu lỗi chưa có nhập kho thật"
                 if is_invalid_paid
-                else "phiếu nháp"
+                else ("phiếu nháp" if current_status == "draft" else "phiếu đã đặt")
             )
             action_label = "xóa" if clean_action == "delete" else "hủy"
             message = f"Đã {action_label} {repaired_label}."

--- a/static/modules/controllers/purchases-controller.js
+++ b/static/modules/controllers/purchases-controller.js
@@ -189,29 +189,22 @@ export function registerPurchasesControllerEvents(contract) {
         actions.showToast("Chỉ được xóa hẳn phiếu nhập nháp hoặc phiếu lỗi chưa nhập kho.", true);
         return;
       }
-      if (queries.isRepairableInvalidPurchase(purchase)) {
-        if (!window.confirm("Phiếu này đang ở trạng thái lỗi dữ liệu. Xóa phiếu sẽ dọn luôn trạng thái thanh toán lỗi và không khôi phục lại phiếu nháp.\n\nBạn có chắc muốn xóa phiếu này?")) {
-          return;
-        }
-        try {
-          const data = await actions.apiRequest("/api/purchases/repair", {
-            method: "POST",
-            body: JSON.stringify({
-              purchase_id: purchase.id,
-              action: "delete",
-            }),
-          });
-          await actions.refreshData();
-          actions.showToast(data.message);
-        } catch (error) {
-          actions.showToast(error.message, true);
-        }
+      if (queries.isRepairableInvalidPurchase(purchase) && !window.confirm("Phiếu này đang ở trạng thái lỗi dữ liệu. Xóa phiếu sẽ dọn luôn trạng thái thanh toán lỗi và không khôi phục lại phiếu nháp.\n\nBạn có chắc muốn xóa phiếu này?")) {
         return;
       }
-      state.purchases = state.purchases.filter((entry) => entry.id !== purchase.id);
-      state.activePurchaseId = state.purchases.find((entry) => entry.status === "draft")?.id || null;
-      actions.saveAndRenderAll(["purchases"]);
-      actions.showToast("Đã xóa phiếu nhập.");
+      try {
+        const data = await actions.apiRequest("/api/purchases/repair", {
+          method: "POST",
+          body: JSON.stringify({
+            purchase_id: purchase.id,
+            action: "delete",
+          }),
+        });
+        await actions.refreshData();
+        actions.showToast(data.message);
+      } catch (error) {
+        actions.showToast(error.message, true);
+      }
       return;
     }
     if (actionButton.dataset.purchaseAction === "mark-ordered") {
@@ -229,28 +222,25 @@ export function registerPurchasesControllerEvents(contract) {
         actions.showToast("Phiếu nhập đã khóa, không thể hủy trực tiếp.", true);
         return;
       }
-      if (queries.isRepairableInvalidPurchase(purchase)) {
-        if (!window.confirm("Phiếu này đang ở trạng thái lỗi dữ liệu. Hủy phiếu sẽ bỏ trạng thái thanh toán lỗi và giữ phiếu ở dạng đã hủy, không quay lại nháp.\n\nBạn có chắc muốn hủy phiếu này?")) {
-          return;
-        }
-        try {
-          const data = await actions.apiRequest("/api/purchases/repair", {
-            method: "POST",
-            body: JSON.stringify({
-              purchase_id: purchase.id,
-              action: "cancel",
-            }),
-          });
-          await actions.refreshData();
-          actions.showToast(data.message);
-        } catch (error) {
-          actions.showToast(error.message, true);
-        }
+      const confirmMessage = queries.isRepairableInvalidPurchase(purchase)
+        ? "Phiếu này đang ở trạng thái lỗi dữ liệu. Hủy phiếu sẽ bỏ trạng thái thanh toán lỗi và giữ phiếu ở dạng đã hủy, không quay lại nháp.\n\nBạn có chắc muốn hủy phiếu này?"
+        : "Hủy phiếu này sẽ giữ lại lịch sử ở trạng thái đã hủy.\n\nBạn có chắc muốn tiếp tục?";
+      if (!window.confirm(confirmMessage)) {
         return;
       }
-      actions.updatePurchase(purchase.id, () => ({ status: "cancelled", supplierName: dom.purchaseSupplierInput.value.trim(), note: dom.purchaseNoteInput.value.trim() }));
-      actions.saveAndRenderAll(["purchases"]);
-      actions.showToast("Đã hủy phiếu nhập.");
+      try {
+        const data = await actions.apiRequest("/api/purchases/repair", {
+          method: "POST",
+          body: JSON.stringify({
+            purchase_id: purchase.id,
+            action: "cancel",
+          }),
+        });
+        await actions.refreshData();
+        actions.showToast(data.message);
+      } catch (error) {
+        actions.showToast(error.message, true);
+      }
       return;
     }
     if (actionButton.dataset.purchaseAction === "mark-paid") {

--- a/static/modules/domain-helpers/purchases-domain.js
+++ b/static/modules/domain-helpers/purchases-domain.js
@@ -27,13 +27,21 @@ export function createPurchasesDomainHelpers(deps) {
   }
 
   function isRepairableInvalidPurchase(purchase) {
-    if (!purchase || purchase.status !== "paid") return false;
+    if (!purchase) return false;
     if (purchase.isRepairableInvalid === true || purchase.repairableInvalid === true) {
       return true;
     }
+    const status = String(purchase.status || "draft").trim();
     const receivedAt = String(purchase.receivedAt || purchase.received_at || "").trim();
+    const paidAt = String(purchase.paidAt || purchase.paid_at || "").trim();
     const receiptCode = String(purchase.receiptCode || purchase.receipt_code || "").trim();
-    return !receivedAt || !receiptCode;
+    if (status === "paid") {
+      return !receivedAt || !receiptCode;
+    }
+    if (["draft", "ordered"].includes(status)) {
+      return Boolean(receivedAt || paidAt || receiptCode);
+    }
+    return false;
   }
 
   function canEditPurchase(purchase) {

--- a/static/modules/screen-config.js
+++ b/static/modules/screen-config.js
@@ -115,7 +115,7 @@ export const SCREEN_HELP = {
       "Trong detail từng dòng nhập, bạn có thể sửa số lượng, giá nhập và bấm Giá chung để cập nhật giá nhập mặc định của sản phẩm sau khi xác nhận.",
       "Nếu đang gõ tên NCC mới chưa có sẵn, bấm nút NCC để mở thẳng form nhà cung cấp với tên đang nhập; nếu tên đó đã có, app sẽ mở luôn chế độ sửa NCC rồi quay lại phiếu nhập sau khi lưu.",
       "Phiếu nhập chỉ được đánh dấu đã thanh toán sau khi đã nhập kho; app sẽ khóa thao tác trả tiền sớm hơn bước này.",
-      "Nếu gặp dữ liệu lỗi cũ kiểu phiếu đang là Đã thanh toán nhưng chưa có mốc Nhập kho hợp lệ, app sẽ hiện cảnh báo và cho phép Hủy/Xóa để dọn trạng thái lỗi mà không khôi phục lại thành nháp.",
+      "Nếu gặp dữ liệu lỗi cũ kiểu phiếu bị lệch marker/trạng thái, như dính Đã thanh toán nhưng chưa có Nhập kho thật hoặc đang hiện thành Nháp sai, app sẽ hiện cảnh báo và cho phép Hủy/Xóa để dọn trạng thái lỗi mà không khôi phục lại thành nháp.",
       "Phiếu đã nhập kho, đã thanh toán hoặc đã hủy sẽ chuyển sang chế độ chỉ xem; nếu sai sót thì bấm Trả NCC trên phiếu cũ hoặc mở khối Phiếu trả NCC để lập phiếu độc lập.",
       "Master Admin cũng không được xóa hoặc hủy ngược phiếu đã khóa, trừ ngoại lệ phiếu lỗi dữ liệu nói trên; ngoài ngoại lệ đó thì chỉ phiếu nháp mới được xóa hẳn.",
       "Ẩn các phiếu đã thanh toán để giữ màn hình gọn; bật lại khi cần đối chiếu lịch sử.",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -265,12 +265,64 @@ class InventoryStoreTests(unittest.TestCase):
             }
         )
 
-        with self.assertRaisesRegex(ValueError, "Chỉ được xóa/hủy phiếu nhập nháp hoặc phiếu lỗi"):
+        with self.assertRaisesRegex(ValueError, "xử lý phiếu lỗi chưa có nhập kho thật"):
             self.store.repair_purchase_document(
                 "purchase-valid-01",
                 action="delete",
                 actor="masteradmin",
             )
+
+    def test_ut_db_09_repair_purchase_document_cancels_draft_with_paid_markers(self) -> None:
+        product = self.store.create_product(
+            name="Phiếu nháp lệch marker",
+            category="Đông lạnh",
+            unit="gói",
+            low_stock_threshold=1,
+        )
+        now = "2026-04-19T10:10:00+07:00"
+        with self.store._connect() as connection:
+            self.store._replace_sync_collection_records(
+                connection,
+                "purchases",
+                [
+                    {
+                        "id": "purchase-draft-broken-01",
+                        "supplierName": "NCC Draft Broken",
+                        "status": "draft",
+                        "note": "Nháp nhưng còn marker thanh toán",
+                        "createdAt": "2026-04-19T10:00:00+07:00",
+                        "updatedAt": now,
+                        "paidAt": now,
+                        "receiptCode": "PN-DRAFT-BROKEN-01",
+                        "items": [
+                            {
+                                "id": "purchase-item-draft-broken-01",
+                                "productId": product["id"],
+                                "productName": product["name"],
+                                "quantity": 1,
+                                "unitCost": 18000,
+                            }
+                        ],
+                    }
+                ],
+            )
+            canonical = self.store._load_sync_collection_from_tables(connection, "purchases")
+            connection.execute(
+                "UPDATE app_state SET state_value = ?, updated_at = ? WHERE state_key = ?",
+                (json.dumps(canonical, ensure_ascii=False), now, "purchases"),
+            )
+
+        result = self.store.repair_purchase_document(
+            "purchase-draft-broken-01",
+            action="cancel",
+            actor="masteradmin",
+        )
+        repaired = result["purchases"][0]
+        self.assertEqual(repaired["status"], "cancelled")
+        self.assertEqual(repaired["paidAt"], None)
+        self.assertEqual(repaired["receivedAt"], None)
+        self.assertEqual(repaired["receiptCode"], "")
+        self.assertIn("phiếu lỗi", result["message"])
 
     def test_ut_rep_01_monthly_report_separates_phase_b_receipts_from_sales_and_purchases(self) -> None:
         product = self.store.create_product(


### PR DESCRIPTION
Fix dữ liệu Nháp nhưng bên trong còn sót marker kiểu paidAt/receivedAt/receiptCode, app sẽ coi đó là phiếu lỗi và vẫn cho Hủy/Xóa thay vì bị kẹt theo workflow thường.

Phần quan trọng:
• qltpchay/store.py: nới nhận diện phiếu lỗi từ chỉ status=paid sang cả ca draft/ordered nhưng còn marker thanh toán/nhập kho; cho phép: • xóa với phiếu draft hoặc phiếu lỗi
• hủy với phiếu draft, ordered, hoặc phiếu lỗi
• khi xử lý phiếu lỗi sẽ xóa sạch marker sai và gỡ liên kết source liên quan nếu có • static/modules/controllers/purchases-controller.js: Hủy/Xóa không còn đi đường mutate sync local nữa, mà gọi thẳng API server-side để tránh bị chặn vì state hiển thị và DB thật bị lệch. • static/modules/domain-helpers/purchases-domain.js: nhận diện cả ca “hiện nháp nhưng dính marker lỗi”.